### PR TITLE
Refactor filter buttons into WidgetFilterButton.qml

### DIFF
--- a/mpop_kiosk/BilingualText.qml
+++ b/mpop_kiosk/BilingualText.qml
@@ -10,26 +10,6 @@ import QtQuick 2.0
 Item {
     property string textFr: ""
     property string textEn: ""
-    property string language: "fr"      // why not directly bind to window.lang here?
-    property string text: ""            // why not directly bind to textFr/textEn according to language instead of adding signals?
-
-    Component.onCompleted: {
-        text = language == "fr" ? textFr : textEn;  // or here?
-    }
-
-    onLanguageChanged: {
-        text = language == "fr" ? textFr : textEn;
-    }
-
-    onTextEnChanged: {
-        if (language == "en") {
-            text = textEn;
-        }
-    }
-
-    onTextFrChanged: {
-        if (language == "fr") {
-            text = textFr;
-        }
-    }
+    property string language: window.lang
+    property string text: language == "fr" ? textFr : textEn
 }

--- a/mpop_kiosk/BilingualText.qml
+++ b/mpop_kiosk/BilingualText.qml
@@ -10,11 +10,11 @@ import QtQuick 2.0
 Item {
     property string textFr: ""
     property string textEn: ""
-    property string language: "fr"
-    property string text: ""
+    property string language: "fr"      // why not directly bind to window.lang here?
+    property string text: ""            // why not directly bind to textFr/textEn according to language instead of adding signals?
 
     Component.onCompleted: {
-        text = language == "fr" ? textFr : textEn;
+        text = language == "fr" ? textFr : textEn;  // or here?
     }
 
     onLanguageChanged: {

--- a/mpop_kiosk/PageSingleQuestion.qml
+++ b/mpop_kiosk/PageSingleQuestion.qml
@@ -315,6 +315,7 @@ ColumnLayout {
                         spacing: 15
                         visible: ageVisualization
 
+                        // section title
                         Text {
                             text: sectionTitle
                             color: "#fff"
@@ -332,8 +333,16 @@ ColumnLayout {
                             columnSpacing: 10
 
                             Repeater {
+                                id: filterRepeater
                                 model: filters
-                                WidgetFilterButton { text: label; checked: index === 0 }
+                                property int currentIndex: 0
+
+                                // filter button
+                                WidgetFilterButton {
+                                    text: label;
+                                    checked: index === filterRepeater.currentIndex;
+                                    onClicked: filterRepeater.currentIndex = index
+                                }
                             }
                         }
                     }

--- a/mpop_kiosk/PageSingleQuestion.qml
+++ b/mpop_kiosk/PageSingleQuestion.qml
@@ -182,7 +182,11 @@ ColumnLayout {
                 spacing: 24
                 visible: buttonsVisibility
 
-                // TODO: wrap in Repeater
+                // reset on RFID tag change
+                property variant resetter: window.rfidTag
+                onResetterChanged: filterHighlighted = ""
+
+                // TODO: wrap in Repeater and simplify identifier declarations
                 WidgetFilterButton {
                     label: BilingualText { textEn: "Age"; textFr: "Âge"; language: window.lang }
                     checked: filterHighlighted === "ageBtn"
@@ -313,6 +317,13 @@ ColumnLayout {
 
                     // display
                     ColumnLayout {
+                        id: subfilter
+
+                        property int currentIndex: 0
+                        // reset index when RFID tag changes
+                        property variant resetter: window.rfidTag
+                        onResetterChanged: currentIndex = 0
+
                         Layout.fillWidth: true
                         Layout.alignment: Qt.AlignLeft
 
@@ -335,7 +346,6 @@ ColumnLayout {
                                 id: sectionTitle
                                 textEn: sectionTitleEn
                                 textFr: sectionTitleFr
-                                language: window.lang
                             }
                         }
 
@@ -345,24 +355,20 @@ ColumnLayout {
                             spacing: 10
 
                             Repeater {
-                                id: filterRepeater
                                 model: filters
-                                property int currentIndex: 0
 
                                 // filter button
                                 WidgetFilterButton {
-                                    label: BilingualText { textEn: model.textEn; textFr: model.textFr; language: window.lang }
+                                    label: BilingualText { textEn: model.textEn; textFr: model.textFr }
 
-                                    checked: index === filterRepeater.currentIndex;
-                                    onClicked: filterRepeater.currentIndex = index
+                                    checked: index === subfilter.currentIndex
+                                    onClicked: subfilter.currentIndex = index
                                 }
                             }
                         }
                     }
                 }
             }
-
-
 
             RowLayout {
                 Layout.fillWidth: true

--- a/mpop_kiosk/PageSingleQuestion.qml
+++ b/mpop_kiosk/PageSingleQuestion.qml
@@ -184,25 +184,25 @@ ColumnLayout {
 
                 // TODO: wrap in Repeater
                 WidgetFilterButton {
-                    text: qsTr("Age")
+                    label: BilingualText { textEn: "Age"; textFr: "Âge"; language: window.lang }
                     checked: filterHighlighted === "ageBtn"
                     onClicked: filterHighlighted = "ageBtn"
                 }
 
                 WidgetFilterButton {
-                    text: qsTr("Genre")
+                    label: BilingualText { textEn: "Gender"; textFr: "Genre"; language: window.lang }
                     checked: filterHighlighted === "genreBtn"
                     onClicked: filterHighlighted = "genreBtn"
                 }
 
                 WidgetFilterButton {
-                    text: qsTr("Culture")
+                    label: BilingualText { textEn: "Culture"; textFr: "Culture"; language: window.lang }
                     checked: filterHighlighted === "cultureBtn"
                     onClicked: filterHighlighted = "cultureBtn"
                 }
 
                 WidgetFilterButton {
-                    text: qsTr("Language")
+                    label: BilingualText { textEn: "Language"; textFr: "Langue"; language: window.lang }
                     checked: filterHighlighted === "langBtn"
                     onClicked: filterHighlighted = "langBtn"
                 }
@@ -274,35 +274,38 @@ ColumnLayout {
                     // model
                     model: ListModel {
                         ListElement {
-                            sectionTitle: qsTr("Culture")
+                            sectionTitleEn: "Culture"
+                            sectionTitleFr: "Culture"
                             filters: [
-                                ListElement { label: qsTr("All") },
-                                ListElement { label: qsTr("Quebecois") },
-                                ListElement { label: qsTr("Canadian") },
-                                ListElement { label: qsTr("Native") },
-                                ListElement { label: qsTr("American") },
-                                ListElement { label: qsTr("European") },
-                                ListElement { label: qsTr("Other") }
+                                ListElement { textEn: "All"; textFr: "Tous" },
+                                ListElement { textEn: "Quebecois"; textFr: "Québécoise" },
+                                ListElement { textEn: "Canadian"; textFr: "Canadienne" },
+                                ListElement { textEn: "Native"; textFr: "Autochtone" },
+                                ListElement { textEn: "American"; textFr: "Américaine" },
+                                ListElement { textEn: "European"; textFr: "Européenne" },
+                                ListElement { textEn: "Other"; textFr: "Autre" }
                             ]
                         }
 
                         ListElement {
-                            sectionTitle: qsTr("Genre")
+                            sectionTitleEn: "Gender"
+                            sectionTitleFr: "Genre"
                             filters: [
-                                ListElement { label: qsTr("All") },
-                                ListElement { label: qsTr("Male") },
-                                ListElement { label: qsTr("Female") },
-                                ListElement { label: qsTr("Other") }
+                                ListElement { textEn: "All"; textFr: "Tous" },
+                                ListElement { textEn: "Male"; textFr: "Homme" },
+                                ListElement { textEn: "Female"; textFr: "Femme" },
+                                ListElement { textEn: "Other"; textFr: "Autre" }
                             ]
                         }
 
                         ListElement {
-                            sectionTitle: qsTr("Time")
+                            sectionTitleEn: "Time"
+                            sectionTitleFr: "Temps"
                             filters: [
-                                ListElement { label: qsTr("All") },
-                                ListElement { label: qsTr("Today") },
-                                ListElement { label: qsTr("This Year") },
-                                ListElement { label: qsTr("From the beginning") }
+                                ListElement { textEn: "All"; textFr: "Tous" },
+                                ListElement { textEn: "Today"; textFr: "Aujourd'hui" },
+                                ListElement { textEn: "This year"; textFr: "Cette année" },
+                                ListElement { textEn: "From the beginning"; textFr: "Depuis le début" }
                             ]
                         }
                     }
@@ -317,7 +320,7 @@ ColumnLayout {
 
                         // section title
                         Text {
-                            text: sectionTitle
+                            text: sectionTitle.text
                             color: "#fff"
                             font {
                                 family: "Trim SemiBold"
@@ -325,6 +328,13 @@ ColumnLayout {
                                 pixelSize: 11
                                 letterSpacing: 11 * 25 / 1000
                                 capitalization: Font.AllUppercase
+                            }
+
+                            BilingualText {
+                                id: sectionTitle
+                                textEn: sectionTitleEn
+                                textFr: sectionTitleFr
+                                language: window.lang
                             }
                         }
 
@@ -339,7 +349,8 @@ ColumnLayout {
 
                                 // filter button
                                 WidgetFilterButton {
-                                    text: label;
+                                    label: BilingualText { textEn: model.textEn; textFr: model.textFr; language: window.lang }
+
                                     checked: index === filterRepeater.currentIndex;
                                     onClicked: filterRepeater.currentIndex = index
                                 }

--- a/mpop_kiosk/PageSingleQuestion.qml
+++ b/mpop_kiosk/PageSingleQuestion.qml
@@ -20,10 +20,7 @@ ColumnLayout {
     property bool sliderWidgetVisibility: true
     property bool buttonsVisibility: false
     property bool ageVisualization: false
-    property bool ageHighlighted: false
-    property bool genreHighlighted: false
-    property bool cultureHighlighted: false
-    property bool languageHighlighted: false
+    property string filterHighlighted: ""
     property bool buttonTextHighlight: true
     property string lang: ""
 
@@ -120,7 +117,6 @@ ColumnLayout {
                             sliderWidgetVisibility = true
                             buttonsVisibility = false
                             ageVisualization = false
-
                         }
                     }
                     RoundButton {
@@ -176,82 +172,43 @@ ColumnLayout {
                 }
             }
 
+            // 1st-level filters
             RowLayout{
                 id: root
-                Layout.fillWidth: true
                 Layout.fillHeight: true
                 //Layout.margins: 0
-                Layout.leftMargin: 170
+                Layout.alignment: Qt.AlignHCenter
                 //Layout.alignment: Qt.AlignHCenter | Qt.AlignVCenter
                 spacing: 24
                 visible: buttonsVisibility
-                Button {
-                    id: ageBtn
+
+                // TODO: wrap in Repeater
+                WidgetFilterButton {
                     text: qsTr("Age")
-                    highlighted : ageHighlighted
-                    background: Rectangle {
-                        color: "#000"
-                        implicitWidth: 140
-                        implicitHeight: 55
-                        border.color: ageHighlighted ? "#FF0000" : "#fff"
-                        border.width: ageHighlighted ? 2 : 1
-                        radius: 2
-                    }
-                    onClicked: {
-                        highlighSelectedButton("ageBtn")
-                    }
-                }
-                Button {
-                    id: genreBtn
-                    text: qsTr("Genre")
-                    highlighted: genreHighlighted
-                    background: Rectangle {
-                        color: "#000"
-                        implicitWidth: 140
-                        implicitHeight: 55
-                        border.color: genreHighlighted ? "#FF0000" : "#fff"
-                        border.width: genreHighlighted ? 2 : 1
-                        radius: 2
-                    }
-                    onClicked: {
-                        highlighSelectedButton("genreBtn")
-                    }
-                }
-                Button {
-                    id : cultureBtn
-                    text: qsTr("Culture")
-                    highlighted: cultureHighlighted
-                    background: Rectangle {
-                        color: "#000"
-                        implicitWidth: 140
-                        implicitHeight: 55
-                        border.color: cultureHighlighted ? "#FF0000" : "#fff"
-                        border.width: cultureHighlighted ? 2 : 1
-                        radius: 2
-                    }
-                    onClicked: {
-                        highlighSelectedButton("cultureBtn")
-                    }
-                }
-                Button {
-                    id: langBtn
-                    text: qsTr("Language")
-                    highlighted: languageHighlighted
-                    background: Rectangle {
-                        color: "#000"
-                        implicitWidth: 140
-                        implicitHeight: 55
-                        border.color: languageHighlighted ? "#FF0000" : "#fff"
-                        border.width: languageHighlighted ? 2 : 1
-                        radius: 2
-                    }
-                    onClicked: {
-                        highlighSelectedButton("langBtn")
-                    }
+                    checked: filterHighlighted === "ageBtn"
+                    onClicked: filterHighlighted = "ageBtn"
                 }
 
+                WidgetFilterButton {
+                    text: qsTr("Genre")
+                    checked: filterHighlighted === "genreBtn"
+                    onClicked: filterHighlighted = "genreBtn"
+                }
+
+                WidgetFilterButton {
+                    text: qsTr("Culture")
+                    checked: filterHighlighted === "cultureBtn"
+                    onClicked: filterHighlighted = "cultureBtn"
+                }
+
+                WidgetFilterButton {
+                    text: qsTr("Language")
+                    checked: filterHighlighted === "langBtn"
+                    onClicked: filterHighlighted = "langBtn"
+                }
             }
 
+            // filter navigation
             RowLayout{
                 Layout.fillWidth: true
                 Layout.alignment: Qt.AlignCenter | Qt.AlignCenter
@@ -308,6 +265,7 @@ ColumnLayout {
                 bottomPadding: 30
             }
 
+            // 2nd-level filters
             ColumnLayout {
                 Layout.leftMargin: 30
                 spacing: 30
@@ -375,7 +333,7 @@ ColumnLayout {
 
                             Repeater {
                                 model: filters
-                                WidgetFilterButton { text: label }
+                                WidgetFilterButton { text: label; checked: index === 0 }
                             }
                         }
                     }
@@ -406,30 +364,6 @@ ColumnLayout {
                     }
                 }
             }
-        }
-    }
-
-    function highlighSelectedButton(btnid){
-        if (btnid === "ageBtn") {
-            ageHighlighted = true;
-            genreHighlighted = false;
-            cultureHighlighted = false;
-            languageHighlighted = false;
-        } else if(btnid === "genreBtn") {
-            ageHighlighted = false;
-            genreHighlighted = true;
-            cultureHighlighted = false;
-            languageHighlighted = false;
-        } else if(btnid === "cultureBtn") {
-            ageHighlighted = false;
-            genreHighlighted = false;
-            cultureHighlighted = true;
-            languageHighlighted = false;
-        } else if(btnid === "langBtn"){
-            ageHighlighted = false;
-            genreHighlighted = false;
-            cultureHighlighted = false;
-            languageHighlighted = true;
         }
     }
 

--- a/mpop_kiosk/PageSingleQuestion.qml
+++ b/mpop_kiosk/PageSingleQuestion.qml
@@ -267,6 +267,7 @@ ColumnLayout {
 
             // 2nd-level filters
             ColumnLayout {
+                Layout.fillWidth: true
                 Layout.leftMargin: 30
                 spacing: 30
 
@@ -338,9 +339,10 @@ ColumnLayout {
                             }
                         }
 
-                        GridLayout {
+                        Flow {
+                            Layout.fillWidth: true
                             Layout.leftMargin: -10
-                            columnSpacing: 10
+                            spacing: 10
 
                             Repeater {
                                 id: filterRepeater

--- a/mpop_kiosk/PageSingleQuestion.qml
+++ b/mpop_kiosk/PageSingleQuestion.qml
@@ -308,289 +308,81 @@ ColumnLayout {
                 bottomPadding: 30
             }
 
-
-            RowLayout{
-                Layout.fillWidth: true
-                Layout.alignment: Qt.AlignLeft | Qt.AlignLeft
+            ColumnLayout {
                 Layout.leftMargin: 30
-                spacing: 24
-                visible: ageVisualization
+                spacing: 30
 
-                Button {
-                    id: culturebtn
-                    text: qsTr("Culture")
-                    background: Rectangle {
-                        color: "#000"
-                        implicitWidth: 130
-                        implicitHeight: 55
-                    }
-                }
-
-                GridLayout {
-                    columns: 5
-
-                    Button {
-                        text: qsTr("All")
-                        background: Rectangle {
-                            color: "#000"
-                            implicitWidth: 130
-                            implicitHeight: 55
-                            border.color: "#fff"
-                            border.width: 1
-                            radius: 2
+                Repeater {
+                    // model
+                    model: ListModel {
+                        ListElement {
+                            sectionTitle: qsTr("Culture")
+                            filters: [
+                                ListElement { label: qsTr("All") },
+                                ListElement { label: qsTr("Quebecois") },
+                                ListElement { label: qsTr("Canadian") },
+                                ListElement { label: qsTr("Native") },
+                                ListElement { label: qsTr("American") },
+                                ListElement { label: qsTr("European") },
+                                ListElement { label: qsTr("Other") }
+                            ]
                         }
-                        onClicked: {
 
+                        ListElement {
+                            sectionTitle: qsTr("Genre")
+                            filters: [
+                                ListElement { label: qsTr("All") },
+                                ListElement { label: qsTr("Male") },
+                                ListElement { label: qsTr("Female") },
+                                ListElement { label: qsTr("Other") }
+                            ]
                         }
-                    }
-                    Button {
-                        text: qsTr("Quebecois")
-                        background: Rectangle {
-                            color: "#000"
-                            implicitWidth: 130
-                            implicitHeight: 55
-                            border.color: "#fff"
-                            border.width: 1
-                            radius: 2
-                        }
-                        onClicked: {
 
+                        ListElement {
+                            sectionTitle: qsTr("Time")
+                            filters: [
+                                ListElement { label: qsTr("All") },
+                                ListElement { label: qsTr("Today") },
+                                ListElement { label: qsTr("This Year") },
+                                ListElement { label: qsTr("From the beginning") }
+                            ]
                         }
                     }
-                    Button {
-                        text: qsTr("Canadian")
-                        background: Rectangle {
-                            color: "#000"
-                            implicitWidth: 130
-                            implicitHeight: 55
-                            border.color: "#fff"
-                            border.width: 1
-                            radius: 2
-                        }
-                        onClicked: {
 
-                        }
-                    }
-                    Button {
-                        text: qsTr("Native")
-                        background: Rectangle {
-                            color: "#000"
-                            implicitWidth: 130
-                            implicitHeight: 55
-                            border.color: "#fff"
-                            border.width: 1
-                            radius: 2
-                        }
-                        onClicked: {
+                    // display
+                    ColumnLayout {
+                        Layout.fillWidth: true
+                        Layout.alignment: Qt.AlignLeft
 
-                        }
-                    }
-                    Button {
-                        text: qsTr("American")
-                        background: Rectangle {
-                            color: "#000"
-                            implicitWidth: 130
-                            implicitHeight: 55
-                            border.color: "#fff"
-                            border.width: 1
-                            radius: 2
-                        }
-                        onClicked: {
+                        spacing: 15
+                        visible: ageVisualization
 
+                        Text {
+                            text: sectionTitle
+                            color: "#fff"
+                            font {
+                                family: "Trim SemiBold"
+                                weight: Font.DemiBold
+                                pixelSize: 11
+                                letterSpacing: 11 * 25 / 1000
+                                capitalization: Font.AllUppercase
+                            }
                         }
-                    }
-                    Button {
-                        text: qsTr("European")
-                        background: Rectangle {
-                            color: "#000"
-                            implicitWidth: 130
-                            implicitHeight: 55
-                            border.color: "#fff"
-                            border.width: 1
-                            radius: 2
-                        }
-                        onClicked: {
 
-                        }
-                    }
-                    Button {
-                        text: qsTr("Other")
-                        background: Rectangle {
-                            color: "#000"
-                            implicitWidth: 130
-                            implicitHeight: 55
-                            border.color: "#fff"
-                            border.width: 1
-                            radius: 2
-                        }
-                        onClicked: {
+                        GridLayout {
+                            Layout.leftMargin: -10
+                            columnSpacing: 10
 
+                            Repeater {
+                                model: filters
+                                WidgetFilterButton { text: label }
+                            }
                         }
                     }
                 }
             }
 
-            RowLayout {
-                Layout.fillWidth: true
-                Layout.alignment: Qt.AlignLeft | Qt.AlignLeft
-                Layout.leftMargin: 30
-                spacing: 24
-                visible: ageVisualization
 
-                Button {
-                    text: qsTr("Genre")
-                    background: Rectangle {
-                        color: "#000"
-                        implicitWidth: 130
-                        implicitHeight: 55
-                    }
-                }
-                GridLayout {
-                    columns: 5
-
-                    Button {
-                        text: qsTr("All")
-                        background: Rectangle {
-                            color: "#000"
-                            implicitWidth: 130
-                            implicitHeight: 55
-                            border.color: "#fff"
-                            border.width: 1
-                            radius: 2
-                        }
-                        onClicked: {
-
-                        }
-                    }
-
-
-                    Button {
-                        text: qsTr("Male")
-                        background: Rectangle {
-                            color: "#000"
-                            implicitWidth: 130
-                            implicitHeight: 55
-                            border.color: "#fff"
-                            border.width: 1
-                            radius: 2
-                        }
-                        onClicked: {
-
-                        }
-                    }
-
-                    Button {
-                        text: qsTr("Female")
-                        background: Rectangle {
-                            color: "#000"
-                            implicitWidth: 130
-                            implicitHeight: 55
-                            border.color: "#fff"
-                            border.width: 1
-                            radius: 2
-                        }
-                        onClicked: {
-
-                        }
-                    }
-
-                    Button {
-                        text: qsTr("Other")
-                        background: Rectangle {
-                            color: "#000"
-                            implicitWidth: 130
-                            implicitHeight: 55
-                            border.color: "#fff"
-                            border.width: 1
-                            radius: 2
-                        }
-                        onClicked: {
-
-                        }
-                    }
-                }
-            }
-
-            RowLayout {
-                Layout.fillWidth: true
-                Layout.alignment: Qt.AlignLeft | Qt.AlignLeft
-                Layout.leftMargin: 30
-                spacing: 24
-                visible: ageVisualization
-                Button {
-                    text: qsTr("Time")
-                    background: Rectangle {
-                        color: "#000"
-                        implicitWidth: 130
-                        implicitHeight: 55
-                    }
-                    onClicked: {
-
-                    }
-                }
-                GridLayout {
-                    columns: 5
-
-                    Button {
-                        text: qsTr("All")
-                        background: Rectangle {
-                            color: "#000"
-                            implicitWidth: 130
-                            implicitHeight: 55
-                            border.color: "#fff"
-                            border.width: 1
-                            radius: 2
-                        }
-                        onClicked: {
-
-                        }
-                    }
-                    Button {
-                        text: qsTr("Today")
-                        background: Rectangle {
-                            color: "#000"
-                            implicitWidth: 130
-                            implicitHeight: 55
-                            border.color: "#fff"
-                            border.width: 1
-                            radius: 2
-                        }
-                        onClicked: {
-
-                        }
-                    }
-
-                    Button {
-                        text: qsTr("This Year")
-                        background: Rectangle {
-                            color: "#000"
-                            implicitWidth: 130
-                            implicitHeight: 55
-                            border.color: "#fff"
-                            border.width: 1
-                            radius: 2
-                        }
-                        onClicked: {
-
-                        }
-                    }
-
-                    Button {
-                        text: qsTr("From the beginning")
-                        background: Rectangle {
-                            color: "#000"
-                            implicitWidth: 140
-                            implicitHeight: 55
-                            border.color: "#fff"
-                            border.width: 1
-                            radius: 2
-                        }
-                        onClicked: {
-
-                        }
-                    }
-                }
-            }
 
             RowLayout {
                 Layout.fillWidth: true
@@ -598,6 +390,7 @@ ColumnLayout {
                 Layout.topMargin: 30
                 Layout.leftMargin: 500
                 visible: ageVisualization
+
                 RoundButton {
                     text: qsTr("Left")
                     //icon.source: "leftarrow.svg"

--- a/mpop_kiosk/Palette.qml
+++ b/mpop_kiosk/Palette.qml
@@ -1,0 +1,11 @@
+pragma Singleton
+
+import QtQuick 2.12
+
+QtObject {
+    readonly property color WHITE: "#ffffff"
+    readonly property color LIGHTBLACK: "#252525"
+    readonly property color ACCENT: "#bbedc9"
+    readonly property color LIGHTGREY: "#e6e6e6"
+    readonly property color MEDIUMGREY: "#696969"
+}

--- a/mpop_kiosk/WidgetFilterButton.qml
+++ b/mpop_kiosk/WidgetFilterButton.qml
@@ -8,6 +8,9 @@ Button {
     text: label.text
     checkable: true
 
+    leftPadding: 20
+    rightPadding: 20
+
     font {
         family: "Trim SemiBold"
         pixelSize: 20
@@ -21,9 +24,6 @@ Button {
         color: checked ? "#000" : "#fff"
         font: widgetFilterButton.font
     }
-
-    leftPadding: 20
-    rightPadding: 20
 
     background: Rectangle {
         color: checked ? "#fff" : "transparent"

--- a/mpop_kiosk/WidgetFilterButton.qml
+++ b/mpop_kiosk/WidgetFilterButton.qml
@@ -1,0 +1,32 @@
+import QtQuick 2.12
+import QtQuick.Controls 2.12
+
+Button {
+    id: widgetFilterButton
+    text: "Filter button"
+    checkable: true
+
+    font {
+        family: "Trim SemiBold"
+        pixelSize: 20
+        letterSpacing: 20 * 25 / 1000
+    }
+
+    contentItem: Text {
+        text: widgetFilterButton.text
+        horizontalAlignment: Text.AlignHCenter
+        verticalAlignment: Text.AlignVCenter
+        color: checked ? "#000" : "#fff"
+        font: widgetFilterButton.font
+    }
+
+    leftPadding: 20
+    rightPadding: 20
+
+    background: Rectangle {
+        color: checked ? "#fff" : "transparent"
+        implicitHeight: 40
+        border.color: "#fff"
+        radius: 30
+    }
+}

--- a/mpop_kiosk/WidgetFilterButton.qml
+++ b/mpop_kiosk/WidgetFilterButton.qml
@@ -2,8 +2,10 @@ import QtQuick 2.12
 import QtQuick.Controls 2.12
 
 Button {
+    property BilingualText label
+
     id: widgetFilterButton
-    text: "Filter button"
+    text: label.text
     checkable: true
 
     font {

--- a/mpop_kiosk/main.qml
+++ b/mpop_kiosk/main.qml
@@ -14,6 +14,7 @@ ApplicationWindow {
     property string lastRfidRead: ""
     property string lastMessageReceived: ""
     property alias lang: userProfile.language // All the BilingualText items watch this value
+    property alias rfidTag: userProfile.rfidTag
 
     readonly property string const_KIOSK_MODE_ENTRY: "entry"
     readonly property string const_KIOSK_MODE_CENTRAL: "central"
@@ -261,7 +262,6 @@ ApplicationWindow {
         sequence: "9"
         onActivated: userProfile.setFakeRfidTag(9, setFakeRfidTagCb)
     }
-
 
     /**
      * The main model that contains all the questions.

--- a/mpop_kiosk/qml.qrc
+++ b/mpop_kiosk/qml.qrc
@@ -25,5 +25,6 @@
         <file>rightarrow.svg</file>
         <file>ModelPageButtons.qml</file>
         <file>BilingualText.qml</file>
+        <file>WidgetFilterButton.qml</file>
     </qresource>
 </RCC>

--- a/mpop_kiosk/qml.qrc
+++ b/mpop_kiosk/qml.qrc
@@ -26,5 +26,7 @@
         <file>ModelPageButtons.qml</file>
         <file>BilingualText.qml</file>
         <file>WidgetFilterButton.qml</file>
+        <file>Palette.qml</file>
+        <file>qmldir</file>
     </qresource>
 </RCC>

--- a/mpop_kiosk/qmldir
+++ b/mpop_kiosk/qmldir
@@ -1,0 +1,1 @@
+singleton Palette 1.0 Palette.qml


### PR DESCRIPTION
Closes #270, closes #267.

Along with the technical details listed in the issue, I also simplified the `BilingualText.qml` component by removing all signal hooks and callbacks, instead directly binding to properties (such as `window.lang`). Also, the 2nd item in the aforemenetioned details list has been discarded in favor of a properly-nested structure using `ColumnLayout` and `Flow` items to allow for proper line wrapping. 2nd-level filter buttons are not connected to the backend.